### PR TITLE
12.0 joint buying base add index on mixin

### DIFF
--- a/joint_buying_base/demo/res_users.xml
+++ b/joint_buying_base/demo/res_users.xml
@@ -7,7 +7,8 @@
 
 <odoo>
 
-    <record id="joint_buying_manager" model="res.users">
+    <record id="joint_buying_manager" model="res.users"
+        context="{'no_reset_password': True}">
         <field name="name">Logistic Manager</field>
         <field name="login">LOG_manager</field>
         <field name="password">demo</field>

--- a/joint_buying_base/models/joint_buying_mixin.py
+++ b/joint_buying_base/models/joint_buying_mixin.py
@@ -13,6 +13,7 @@ class JointBuyingMixin(models.AbstractModel):
     is_joint_buying = fields.Boolean(
         string="For Joint Buyings",
         readonly=True,
+        index=True,
         default=lambda x: x._default_is_joint_buying(),
     )
 


### PR DESCRIPTION
### AVANT PATCH
```
grap_production=# EXPLAIN ANALYZE SELECT * FROM res_partner WHERE is_joint_buying = false AND company_id = 1;
                                                                   QUERY PLAN                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using res_partner_company_id_index on res_partner  (cost=0.29..759.31 rows=1660 width=828) (actual time=2.751..2.752 rows=0 loops=1)
   Index Cond: (company_id = 1)
   Filter: (NOT is_joint_buying)
   Rows Removed by Filter: 1665
 Planning time: 0.321 ms
 Execution time: 2.821 ms
(6 rows)
```


### APRES PATCH

```
grap_production__2021_03_04__03_20_01=# EXPLAIN ANALYZE SELECT * FROM res_partner WHERE is_joint_buying = false AND company_id = 1;
                                                                     QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using res_partner_is_joint_buying_index on res_partner  (cost=0.29..2.51 rows=1660 width=828) (actual time=0.022..0.022 rows=0 loops=1)
   Index Cond: (is_joint_buying = false)
   Filter: ((NOT is_joint_buying) AND (company_id = 1))
   Rows Removed by Filter: 1
 Planning time: 0.225 ms
 Execution time: 0.060 ms
(6 rows)

```

Execution time : 2.8 >> 0.06 : 46 fois plus rapide.

(ref commit 1, sur l'index)

