### PR TITLE
[FIX] joint_buying_product: Use Minimum values (amount / weight / grouped / unit) 

### DIFF
--- a/joint_buying_product/models/joint_buying_frequency.py
+++ b/joint_buying_product/models/joint_buying_frequency.py
@@ -68,3 +68,17 @@ class JointBuyingFrequency(models.Model):
             raise ValidationError(_("The start date must be less than the end date."))
         elif self.next_end_date >= datetime.combine(self.next_deposit_date, time(0, 0)):
             raise ValidationError(_("The end date must be less than the deposit date."))
+
+    def _prepare_wizard_values(self):
+        self.ensure_one()
+        return {
+            "category_ids": [(6, 0, self.category_ids.ids)],
+            "start_date": self.next_start_date,
+            "end_date": self.next_end_date,
+            "deposit_date": self.next_deposit_date,
+            "deposit_partner_id": self.deposit_partner_id.id,
+            "minimum_amount": self.minimum_amount,
+            "minimum_weight": self.minimum_weight,
+            "minimum_unit_amount": self.minimum_unit_amount,
+            "minimum_unit_weight": self.minimum_unit_weight,
+        }

--- a/joint_buying_product/models/joint_buying_purchase_order_grouped.py
+++ b/joint_buying_product/models/joint_buying_purchase_order_grouped.py
@@ -317,15 +317,7 @@ class JointBuyingPurchaseOrderGrouped(models.Model):
             wizard = (
                 self.env["joint.buying.wizard.create.order"]
                 .with_context(active_id=frequency.partner_id.id)
-                .create(
-                    {
-                        "category_ids": [(6, 0, frequency.category_ids.ids)],
-                        "start_date": frequency.next_start_date,
-                        "end_date": frequency.next_end_date,
-                        "deposit_date": frequency.next_deposit_date,
-                        "deposit_partner_id": frequency.deposit_partner_id.id,
-                    }
-                )
+                .create(frequency._prepare_wizard_values())
             )
             wizard.create_order_grouped()
 

--- a/joint_buying_product/tests/test_module.py
+++ b/joint_buying_product/tests/test_module.py
@@ -440,6 +440,10 @@ class TestModule(TransactionCase):
             "next_start_date": now + timedelta(days=-1),
             "next_end_date": now + timedelta(days=+8),
             "next_deposit_date": now + timedelta(days=+12),
+            "minimum_amount": 100,
+            "minimum_weight": 10,
+            "minimum_unit_amount": 20,
+            "minimum_unit_weight": 2,
         }
         self.supplier_oscar_morell.write(
             {
@@ -459,9 +463,16 @@ class TestModule(TransactionCase):
         self.assertEqual(
             len(order_grouped), 1, "Creation of Grouped Order by cron failed"
         )
+        # Check dates
         self.assertEqual(order_grouped.start_date, now + timedelta(days=-1))
         self.assertEqual(order_grouped.end_date, now + timedelta(days=+8))
         self.assertEqual(order_grouped.deposit_date, now + timedelta(days=+12))
+
+        # Check Minimum Values
+        self.assertEqual(order_grouped.minimum_amount, 100)
+        self.assertEqual(order_grouped.minimum_weight, 10)
+        self.assertEqual(order_grouped.minimum_unit_amount, 20)
+        self.assertEqual(order_grouped.minimum_unit_weight, 2)
 
         # Check that supplier dateds has been correctly incremented
         self.assertEqual(


### PR DESCRIPTION
- when creating grouped purchase order from partner frequencies
- [REF] joint_buing_product : Define a _prepare function to create wizard values from frequency

Fix : https://erp.grap.coop/web#id=586&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673