### PR TITLE
[FIX] joint_buying_sale : use partner payment term, when preparing sale order 

### DIFF
--- a/joint_buying_sale/models/joint_buying_purchase_order.py
+++ b/joint_buying_sale/models/joint_buying_purchase_order.py
@@ -32,6 +32,8 @@ class JointBuyingPurchaseOrder(models.Model):
             "partner_id": partner.id,
             "company_id": self.env.user.company_id.id,
             "pricelist_id": partner.property_product_pricelist.id,
+            "payment_term_id": partner.property_payment_term_id
+            and partner.property_payment_term_id.id,
             "fiscal_position_id": partner.property_account_position_id
             and partner.property_account_position_id.id,
             "commitment_date": self.grouped_order_id.deposit_date,


### PR DESCRIPTION
(from joint buying purchase order)

https://erp.grap.coop/web#id=880&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673