### PR TITLE
[FIX] joint_buying_product : Do not generate grouped order for disabled partners

### DIFF
--- a/joint_buying_product/models/joint_buying_purchase_order_grouped.py
+++ b/joint_buying_product/models/joint_buying_purchase_order_grouped.py
@@ -327,7 +327,7 @@ class JointBuyingPurchaseOrderGrouped(models.Model):
         frequencies = self.env["joint.buying.frequency"].search(
             [("frequency", "!=", 0), ("next_start_date", "<", now)]
         )
-        for frequency in frequencies:
+        for frequency in frequencies.filtered(lambda x: x.partner_id.active):
             # Create Grouped order
             wizard = (
                 self.env["joint.buying.wizard.create.order"]


### PR DESCRIPTION

https://erp.grap.coop/web#id=887&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673