### PR TITLE
[FIX] joint_buying_base : Summary can not be a stored field, because it depends on non-stored field ('joint_buying_code')

### DIFF
--- a/joint_buying_base/models/joint_buying_tour.py
+++ b/joint_buying_base/models/joint_buying_tour.py
@@ -24,7 +24,7 @@ class JointBuyingTour(models.Model):
 
     name = fields.Char(compute="_compute_name", store=True)
 
-    summary = fields.Text(compute="_compute_summary", store=True)
+    summary = fields.Text(compute="_compute_summary")
 
     description = fields.Html(compute="_compute_description")
 


### PR DESCRIPTION
https://erp.grap.coop/web#id=1061&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673