### PR TITLE
[IMP] joint_buying_purchase: set the name of the joint buying order as the partner_ref of the created purchase.order.

### DIFF
--- a/joint_buying_purchase/wizards/joint_buying_create_purchase_order_wizard.py
+++ b/joint_buying_purchase/wizards/joint_buying_create_purchase_order_wizard.py
@@ -131,6 +131,7 @@ class JointBuyingCreatePurchaseOrderWizard(models.TransientModel):
         partner = self.joint_buying_local_supplier_id
         return {
             "partner_id": partner.id,
+            "partner_ref": self.order_id.name,
             "date_planned": self.date_planned,
             "company_id": self.env.user.company_id.id,
             "fiscal_position_id": partner.property_account_position_id


### PR DESCRIPTION
 So that this name is available in the 'reference' field of the account.invoice, once created.