### PR TITLE
[FIX] joint_buying_product: bad order on purchase view.

### DIFF
--- a/joint_buying_product/views/view_joint_buying_purchase_order.xml
+++ b/joint_buying_product/views/view_joint_buying_purchase_order.xml
@@ -39,6 +39,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <field name="total_weight" sum="Total Brut Weight"/>
                 <field name="amount_untaxed" sum="Total Amount Untaxed"/>
                 <field name="purchase_state" invisible="1"/>
+                <field name="deposit_date" invisible="1"/>
                 <field name="state"/>
             </tree>
         </field>
@@ -220,7 +221,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <xpath expr="//tree" position="attributes">
-                <attribute name="default_order">request_arrival_date desc, supplier_id</attribute>
+                <attribute name="default_order">deposit_date desc, supplier_id</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
rational: #102 introduced an order by request_arrival_date, however this field is not stored in the database, so the fallback order is done on supplier, that is a mess for end user

ticket 1417